### PR TITLE
Expand the list of version of symfony console to use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }],
     "require": {
         "php": ">=5.4",
-        "symfony/console": "^2.8|^3.0|^4.0|v5.0|v6.0",
+        "symfony/console": "^2.8|^3.0|^4.0|^5.0|^6.0",
         "symfony/config": "^2.8|^3.0|^4.0|v5.0|v6.0",
         "symfony/yaml": "^2.8|^3.0|^4.0|v5.0|v6.0",
         "vlucas/phpdotenv": "~3.0"


### PR DESCRIPTION
Use higher versions of Symfony Console V6 not just V6.0.0.